### PR TITLE
readme: Clarifying imports in `list-item-style` README.

### DIFF
--- a/packages/remark-lint-list-item-style/README.md
+++ b/packages/remark-lint-list-item-style/README.md
@@ -66,11 +66,11 @@ import { read } from 'to-vfile';
 import { reporter } from 'vfile-reporter';
 import { remark } from 'remark';
 import remarkLint from 'remark-lint';
-import lintFencedCodeFlagCase from 'remark-lint-list-item-style';
+import remarkLintListItemStyle from 'remark-lint-list-item-style';
 
 const file = await remark()
   .use(remarkLint)
-  .use(lintFencedCodeFlagCase)
+  .use(remarkLintListItemStyle)
   .process(await read('example.md'));
 
 console.log(reporter(file));
@@ -115,12 +115,12 @@ module.exports = {
 In `.remarkrc.mjs`:
 
 ```javascript
-import lintFencedCodeFlagCase from 'remark-lint-list-item-style';
+import remarkLintListItemStyle from 'remark-lint-list-item-style';
 
 export default {
   plugins: [
     // …
-    lintFencedCodeFlagCase
+    remarkLintListItemStyle
   ]
 };
 ```


### PR DESCRIPTION
<!-- Add a brief description of your PR here |-->
Hey there! Thank you for the package, it is awesome! 🤩

This PR just changes the imports in the example of `remark-lint-list-item-style`. It seems the imports may have been copied from `remark-lint-fenced-code-flag-case`, so I'm just making them more precise and relevant to the package :)

<!-- If this PR closes any issues, please enumerate them; i.e. "Closes #4" |-->

<!-- If this PR involves or references any other issues, list them as well -->

---

<!-- Replace `[ ]` with `[x]` in all the following boxes that apply to you -->

- [x] I have read **[CONTRIBUTING.md][1]**.
- [x] This PR is not security related (see [SECURITY.md][2]).

[1]: /CONTRIBUTING.md
[2]: /SECURITY.md
